### PR TITLE
Multi-year registration with 1st year promo

### DIFF
--- a/namesilo.php
+++ b/namesilo.php
@@ -376,12 +376,13 @@ class Namesilo extends Module {
 							$fields['years'] = $total_years - 1;
 							$response = $domains->renew($fields);
 							$this->processResponse($api,$response);
+						} else {
+							if(isset($vars['contact_id']))
+								$domains->deleteContacts(array('contact_id'=>$vars['contact_id']));
+
+							return;
 						}
 
-						if(isset($vars['contact_id']))
-							$domains->deleteContacts(array('contact_id'=>$vars['contact_id']));
-
-						return;
 					}
 				}
 			}


### PR DESCRIPTION
Mentioned/fixed in #31 but I'm a little worried it'll break things..

[L367:L369](https://github.com/NETLINK/Blesta-Namesilo/blob/master/namesilo.php#L367:L379) seem sensible, but after that `if` block (if it is a 1st year then renew) it deletes a contact and the function returns (null, I guess). 

Doesn't this mean that Blesta won't have any idea about this domains "meta" fields that should be returned [here](https://github.com/NETLINK/Blesta-Namesilo/blob/master/namesilo.php#L390)?

¯\_(ツ)_/¯